### PR TITLE
fix: 要素がnilの場合は適当な文字列を入れる

### DIFF
--- a/lib/feeds/builder.rb
+++ b/lib/feeds/builder.rb
@@ -26,20 +26,20 @@ module Feeds
 
     def build_xml(items_for_feed)
       RSS::Maker.make("2.0") do |maker|
-        xss                       = maker.xml_stylesheets.new_xml_stylesheet
-        xss.href                  = ENV["REPOSITORY_URL"]
-        maker.channel.title       = title
-        maker.channel.description = description
-        maker.channel.link        = url
-        maker.items.do_sort       = true
+        xss                       = maker.xml_stylesheets.new_xml_stylesheet || "Content is null."
+        xss.href                  = ENV["REPOSITORY_URL"]                    || "Content is null."
+        maker.channel.title       = title                                    || "Content is null."
+        maker.channel.description = description                              || "Content is null."
+        maker.channel.link        = url                                      || "Content is null."
+        maker.items.do_sort       = true                                     || "Content is null."
 
         items_for_feed.each do |_item|
           next if _item.nil?
 
           maker.items.new_item do |item|
-            item.link  = set_item_link(_item[:path])
-            item.date  = _item[:date]
-            item.title = _item[:title]
+            item.link  = set_item_link(_item[:path]) || "Content is null."
+            item.date  = _item[:date]  || "Content is null."
+            item.title = _item[:title] || "Content is null."
           end
         end
       rescue StandardError => e


### PR DESCRIPTION
/usr/local/lib/ruby/3.1.0/open-uri.rb:31:in `open': no implicit conversion of nil into String (TypeError)